### PR TITLE
[Feature] transliterateアクションを追加する

### DIFF
--- a/json/howToMake.md
+++ b/json/howToMake.md
@@ -98,6 +98,7 @@ azooKeyでは`"input"`の他にいくつかの動作を行うことができま�
 | complete              | なし              | 変換を確定します                                          |
 | replace_last_characters | table: {str: str}                  | カーソル文頭方向の文字列を引数のtableに基づいて置換します。例えばカーソル文頭方向の文字列が`"abcdef"`であり、テーブルに`"def":":="`が指定されている場合は`"abc:="`と置換されます。 |
 | replace_default         | なし                               | azooKeyが標準で用いている「濁点・半濁点・小書き・大文字・小文字」の切り替えアクションです。 |
+| transliterate         | kana: str                            | 入力の仮名文字を全てhiragana/katakana/hankakukatakanaのいずれかで置き換えます。 |
 | smart_delete            | direction: str<br />targets: [str] | directionに`"forward"`または`"backward"`を指定します。targetsに指定した文字のいずれかがカーソル進行方向に現れるまで削除を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、`"direction": "backward", "targets": [","]`であった場合、この操作の実行後に`" it is"`が削除されます。 |
 | smart_delete_default    | なし                               | azooKeyが標準で用いている「文頭まで削除」のアクションです。  |
 | smart_move_cursor       | direction: str<br />targets: [str] | directionに`"forward"`または`"backward"`を指定します。targetsに指定した文字のいずれかがカーソル進行方向に現れるまでカーソルの移動を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、`"direction": "backward", "target": [","]`であった場合、この操作の実行後にカーソルが`"Yes,| it is"`まで移動します。 |

--- a/python/howToMake.md
+++ b/python/howToMake.md
@@ -86,6 +86,7 @@ azooKeyでは`InputAction`の他にいくつかの動作を行うことができ
 | CompleteAction               | なし                                             | 変換を確定します                                                          |
 | ReplaceLastCharactersAction | table: {str: str}                                | カーソル文頭方向の文字列を引数のtableに基づいて置換します。例えばカーソル文頭方向の文字列が`"abcdef"`であり、テーブルに`"def":":="`が指定されている場合は`"abc:="`と置換されます。 |
 | ReplaceDefaultAction         | なし                                             | azooKeyが標準で用いている「濁点・半濁点・小書き・大文字・小文字」の切り替えアクションです。 |
+| Transliterate         | kana: str                                             | 入力の仮名文字を全てhiragana/katakana/hankakukatakanaのいずれかで置き換えます。 |
 | SmartDeleteAction            | direction: ScanDirection<br />targets: list[str] | directionに`ScanDirection.forward`または`ScanDirection.backward`を指定します。targetsに指定した文字のいずれかがカーソル進行方向に現れるまで削除を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、`direction = ScanDirection.backward, target = [","]`であった場合、この操作の実行後に`" it is"`が削除されます。 |
 | SmartDeleteDefaultAction    | なし                                             | azooKeyが標準で用いている「文頭まで削除」のアクションです。  |
 | SmartMoveCursorAction       | direction: ScanDirection<br />target: list[str]  | directionに`ScanDirection.forward`または`ScanDirection.backward`を指定します。targetsに指定した文字のいずれかがカーソル進行方向に現れるまでカーソルの移動を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、`direction = ScanDirection.backward, target = [","]`であった場合、この操作の実行後にカーソルが`"Yes,| it is"`まで移動します。 |

--- a/python/source/actions.py
+++ b/python/source/actions.py
@@ -70,6 +70,26 @@ class ReplaceDefaultAction(metaclass=ActionMeta):
 
 
 @unique
+class KanaTransliteration(str, Enum):
+    katakana = "katakana"
+    hiragana = "hiragana"
+    hankakukatakana = "hankakukatakana"
+
+class TransliterateAction(metaclass=ActionMeta):
+    type = "transliterate"
+
+    def __init__(self, kana: KanaTransliteration):
+        """
+        入力の文字種を変換するアクション
+        Parameters
+        ----------
+        kana: KanaTransliteration
+            カナ文字の変更先の文字種を指定する
+        """
+        self.kana = kana
+
+
+@unique
 class TabType(str, Enum):
     system = "system"
     custom = "custom"

--- a/python/test/test_actions.py
+++ b/python/test/test_actions.py
@@ -32,6 +32,17 @@ class TestActions(unittest.TestCase):
         }
         self.assertEqual(expected_json, actual)
 
+    def test_TransliterateAction(self):
+        """test method for Transliterate
+        """
+        actual = to_json(TransliterateAction(
+            kana=KanaTransliteration.hiragana))
+        expected_json = {
+            "type": "transliterate",
+            "kana": "hiragana"
+        }
+        self.assertEqual(expected_json, actual)
+
     def test_MoveTabAction(self):
         """test method for MoveTabAction
         """

--- a/swift/howToMake.md
+++ b/swift/howToMake.md
@@ -78,6 +78,7 @@ azooKeyでは`input`の他にいくつかの動作を行うことができます
 | .complete              | なし              | 変換を確定します                                          |
 | .replaceLastCharacters | [String: String] | カーソル文頭方向の文字列を引数に基づいて置換します。例えばカーソル文頭方向の文字列が`"abcdef"`であり、テーブルに`"def":":="`が指定されている場合は`"abc:="`と置換されます。 |
 | .replaceDefault        | なし             | azooKeyが標準で用いている「濁点・半濁点・小書き・大文字・小文字」の切り替えアクションです。 |
+| .transliterate         | TransliterationKeyValue | 入力の仮名文字を全てhiragana/katakana/hankakukatakanaのいずれかで置き換えます。 |
 | .smartDelete           | ScanItem         | 引数で指定した方向に、指定した文字を見つけるまで削除を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、方向が`.backward`かつ文字の指定が` [","]`であった場合、この操作の実行後に`" it is"`が削除されます。 |
 | .smartDeleteDefault    | なし             | azooKeyが標準で用いている「文頭まで削除」のアクションです。  |
 | .smartMoveCursor       | ScanItem         | 引数で指定した方向に、指定した文字を見つけるまで移動を繰り返します。例えば文頭方向の文字列が`"Yes, it is"`であり、方向が`.backward`かつ文字の指定が` [","]`であった場合、この操作の実行後に`"Yes,| it is"`まで移動します。 |

--- a/swift/sources/CustardKit.swift
+++ b/swift/sources/CustardKit.swift
@@ -1029,6 +1029,15 @@ public extension CandidateSelection {
     }
 }
 
+public struct TransliterationKeyValues: Codable, Equatable, Hashable, Sendable {
+    public enum KanaTrasnliteration: String, Codable, Equatable, Hashable, Sendable {
+        case katakana
+        case hiragana
+        case hankakukatakana
+    }
+    public var kana: KanaTrasnliteration
+}
+
 /// - アクション
 /// - actions done in key pressing
 public enum CodableActionData: Codable, Hashable, Sendable {
@@ -1044,6 +1053,9 @@ public enum CodableActionData: Codable, Hashable, Sendable {
 
     /// - replace string at the trailing of cursor following to specified table
     case replaceLastCharacters([String: String])
+
+    /// - transliterate input to others
+    case transliterate(TransliterationKeyValues)
 
     /// - delete action specified count of characters
     case delete(Int)
@@ -1102,6 +1114,7 @@ public extension CodableActionData {
         case direction, targets
         case scheme_type, target
         case selection
+        case kana
     }
 
     private enum ValueType: String, Codable {
@@ -1109,6 +1122,7 @@ public extension CodableActionData {
         case paste
         case replace_default
         case replace_last_characters
+        case transliterate
         case delete
         case smart_delete
         case smart_delete_default
@@ -1139,6 +1153,7 @@ public extension CodableActionData {
         case .moveTab: return .move_tab
         case .replaceDefault: return .replace_default
         case .replaceLastCharacters: return .replace_last_characters
+        case .transliterate: return .transliterate
         case .smartDelete: return .smart_delete
         case .smartDeleteDefault: return .smart_delete_default
         case .smartMoveCursor: return .smart_move_cursor
@@ -1205,6 +1220,8 @@ public extension CodableActionData {
             try container.encode(value.target, forKey: .target)
         case let .selectCandidate(value):
             try container.encode(value, forKey: .selection)
+        case let .transliterate(value):
+            try container.encode(value.kana, forKey: .kana)
         case let .moveTab(value):
             try CodableTabArgument(tab: value).containerEncode(container: &container)
         case .dismissKeyboard, .enableResizingMode, .toggleTabBar, .toggleCursorBar, .toggleCapsLockState, .complete, .smartDeleteDefault, .replaceDefault, .paste: break
@@ -1223,6 +1240,9 @@ public extension CodableActionData {
         case .replace_last_characters:
             let value = try container.decode([String: String].self, forKey: .table)
             self = .replaceLastCharacters(value)
+        case .transliterate:
+            let kana = try container.decode(TransliterationKeyValues.KanaTrasnliteration.self, forKey: .kana)
+            self = .transliterate(.init(kana: kana))
         case .delete:
             let value = try container.decode(Int.self, forKey: .count)
             self = .delete(value)

--- a/swift/tests/CustardKitTests/DecodeCodableActionTest.swift
+++ b/swift/tests/CustardKitTests/DecodeCodableActionTest.swift
@@ -58,6 +58,29 @@ final class DecodeCodableActionTest: XCTestCase {
         }
     }
 
+    func testDecodeTransliterate() {
+        do {
+            let target = """
+            {
+                "type": "transliterate",
+                "kana": "katakana"
+            }
+            """
+            let decoded = CodableActionData.quickDecode(target: target)
+            XCTAssertEqual(decoded, .transliterate(.init(kana: .katakana)))
+        }
+        do {
+            let target = """
+            {
+                "type": "transliterate",
+                "kana": "hiragana"
+            }
+            """
+            let decoded = CodableActionData.quickDecode(target: target)
+            XCTAssertEqual(decoded, .transliterate(.init(kana: .hiragana)))
+        }
+    }
+
     func testDecodeDelete() {
         do {
             let target = """

--- a/swift/tests/CustardKitTests/EncodeCodableActionTest.swift
+++ b/swift/tests/CustardKitTests/EncodeCodableActionTest.swift
@@ -21,6 +21,12 @@ final class EncodeCodableActionTest: XCTestCase {
         XCTAssertEqual(target.quickEncodeDecode(), target)
     }
 
+    func testEncodeTransliterate() {
+        XCTAssertEqual(CodableActionData.transliterate(.init(kana: .hankakukatakana)).quickEncodeDecode(), .transliterate(.init(kana: .hankakukatakana)))
+        XCTAssertEqual(CodableActionData.transliterate(.init(kana: .hiragana)).quickEncodeDecode(), .transliterate(.init(kana: .hiragana)))
+        XCTAssertEqual(CodableActionData.transliterate(.init(kana: .katakana)).quickEncodeDecode(), .transliterate(.init(kana: .katakana)))
+    }
+
     func testEncodeDelete() {
         XCTAssertEqual(CodableActionData.delete(9).quickEncodeDecode(), .delete(9))
         XCTAssertEqual(CodableActionData.delete(-1).quickEncodeDecode(), .delete(-1))


### PR DESCRIPTION
* 「あいうえお」が入力にあるとき、これを「アイウエオ」にするのがtransliterateの主な役割